### PR TITLE
Fix stock removal and delay feedback prompt

### DIFF
--- a/bot/database/methods/delete.py
+++ b/bot/database/methods/delete.py
@@ -53,22 +53,11 @@ def finish_operation(operation_id: str) -> None:
 
 
 def buy_item(item_id: str, infinity: bool = False) -> None:
-    """Remove item value record once purchased.
+    """Remove an item's value record after purchase.
 
-    File cleanup is handled after successful delivery to the user."""
-    if infinity is False:
+    File cleanup is handled separately by the caller."""
+    if not infinity:
         session = Database().session
         session.query(ItemValues).filter(ItemValues.id == item_id).delete()
         session.commit()
-
-        session = Database().session
-        session.query(ItemValues).filter(ItemValues.id == item_id).delete()
-        session.commit()
-
-        value = Database().session.query(ItemValues.value).filter(ItemValues.id == item_id).first()
-        if value and os.path.isfile(value[0]):
-            os.remove(value[0])
-        Database().session.query(ItemValues).filter(ItemValues.id == item_id).delete()
-        Database().session.commit()
-    else:
-        pass
+    # Nothing to do for infinite items

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -44,7 +44,13 @@ def build_menu_text(user_obj, balance: float, purchases: int, lang: str) -> str:
         f"{t(lang, 'balance', balance=f'{balance:.2f}')}\n"
         f"{t(lang, 'total_purchases', count=purchases)}\n\n"
         f"{t(lang, 'note')}"
-     )
+    )
+
+
+async def schedule_feedback(bot, user_id: int, lang: str) -> None:
+    """Send feedback prompt 30 minutes after purchase."""
+    await asyncio.sleep(30 * 60)
+    await bot.send_message(user_id, t(lang, 'feedback_service'), reply_markup=feedback_menu('feedback_service'))
 
 
 def build_subcategory_description(parent: str, lang: str) -> str:
@@ -646,7 +652,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                 f'User {username} purchased {value_data["item_name"]} for {item_price}€'
             )
             lang = get_user_language(user_id) or 'en'
-            await bot.send_message(user_id, t(lang, 'feedback_service'), reply_markup=feedback_menu('feedback_service'))
+            asyncio.create_task(schedule_feedback(bot, user_id, lang))
             return
 
         await bot.edit_message_text(chat_id=call.message.chat.id,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -274,11 +274,11 @@ def confirm_cancel(invoice_id: str, lang: str) -> InlineKeyboardMarkup:
 
 def crypto_choice() -> InlineKeyboardMarkup:
     inline_keyboard = [
-        [InlineKeyboardButton('SOLANA', callback_data='crypto_SOL'),
-         InlineKeyboardButton('BITCOIN', callback_data='crypto_BTC')],
+        [InlineKeyboardButton('SOL', callback_data='crypto_SOL'),
+         InlineKeyboardButton('BTC', callback_data='crypto_BTC')],
         [InlineKeyboardButton('TRX', callback_data='crypto_TRX'),
          InlineKeyboardButton('TON', callback_data='crypto_TON')],
-        [InlineKeyboardButton('USDT-TRC20', callback_data='crypto_USDTTRC20'),
+        [InlineKeyboardButton('USDT (TRC20)', callback_data='crypto_USDTTRC20'),
          InlineKeyboardButton('ETH', callback_data='crypto_ETH')],
         [InlineKeyboardButton('LTC', callback_data='crypto_LTC')],
         [InlineKeyboardButton('🔙 Go back', callback_data='replenish_balance')]


### PR DESCRIPTION
## Summary
- remove redundant deletions in `buy_item` so stock updates correctly
- send purchase feedback menu 30 minutes after buying
- use cryptocurrency abbreviations for payment buttons

## Testing
- `pytest`
- `python -m py_compile bot/database/methods/delete.py bot/handlers/user/main.py bot/keyboards/inline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a44e44a1908332a7d1f2903d5d9ced